### PR TITLE
Add support for --force flag and delete service operation

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -131,6 +131,12 @@ jobs:
           service_name: ${{ env.IMAGE_NAME }} 
           container_image: "${{ steps.push-tag-to-quay.outputs.registry-path }}"
           force_create: "true"
-
+      
       - name: Show Kn Service URL
         run: echo ${{ steps.kn_service_deploy.outputs.service_url }}
+
+      - name: Knative Service Delete
+        uses: ./kn-service-deploy/
+        with:
+          service_name: ${{ env.IMAGE_NAME }}
+          service_operation: "delete"

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -128,9 +128,9 @@ jobs:
         id: kn_service_deploy
         uses: ./kn-service-deploy/
         with:
-          service_name: ${{ env.IMAGE_NAME }}
-          service_operation: update
+          service_name: ${{ env.IMAGE_NAME }} 
           container_image: "${{ steps.push-tag-to-quay.outputs.registry-path }}"
+          force_create: "true"
 
       - name: Show Kn Service URL
         run: echo ${{ steps.kn_service_deploy.outputs.service_url }}

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Kubernetes Cluster with Knative, if you dont have an OpenShift cluster see [try.
   <tr>
     <td>force_create</td>
     <td>No</td>
-    <td>Create service forcefully, replaces existing service if any. Only valid for <code>create</code> service operation.
+    <td>Pass `--force` to `kn create` to replace the existing service, instead of failing if the service already exists.
     Defaults to <code>false</code>.
-     </td>
+    </td>
   </tr>
 
   <tr>

--- a/README.md
+++ b/README.md
@@ -24,6 +24,32 @@ Kubernetes Cluster with Knative, if you dont have an OpenShift cluster see [try.
   </thead>
 
   <tr>
+    <td>container_image</td>
+    <td>No</td>
+    <td>The container image to use for service. Not required if <code>service_operation</code> is set to <code>delete</code>. </td>
+  </tr>
+
+  <tr>
+    <td>force_create</td>
+    <td>No</td>
+    <td>Create service forcefully, replaces existing service if any. Only valid for <code>create</code> service operation.
+    Defaults to <code>false</code>.
+     </td>
+  </tr>
+
+  <tr>
+    <td>registry_password</td>
+    <td>No</td>
+    <td>The registry user password or token. Required if image registry is private. </td>
+  </tr>
+
+  <tr>
+    <td>registry_user</td>
+    <td>No</td>
+    <td>The registry user to use to create image pull secret. Required if image registry is private. </td>
+  </tr>
+
+  <tr>
     <td>service_name</td>
     <td>Yes</td>
     <td>
@@ -45,33 +71,10 @@ Kubernetes Cluster with Knative, if you dont have an OpenShift cluster see [try.
   </tr>
 
   <tr>
-    <td>container_image</td>
-    <td>No</td>
-    <td>The container image to use for service. Not required if <code>service_operation</code> is set to <code>delete</code>. </td>
-  </tr>
-
-  <tr>
     <td>service_params</td>
     <td>No</td>
     <td>The extra service parameters to pass to the service. </td>
   </tr>
-  <tr>
-    <td>registry_user</td>
-    <td>No</td>
-    <td>The registry user to use to create image pull secret. Required if image registry is private. </td>
-  </tr>
-  <tr>
-    <td>registry_password</td>
-    <td>No</td>
-    <td>The registry user password or token. Required if image registry is private. </td>
-  </tr>
-  <tr>
-    <td>force_create</td>
-    <td>No</td>
-    <td>Create service forcefully, replaces existing service if any. Only valid for <code>create</code> service operation.
-    Defaults to <code>false</code>.
-     </td>
-  </tr>  
 
 </table>
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ Kubernetes Cluster with Knative, if you dont have an OpenShift cluster see [try.
     <td>No</td>
     <td>The registry user password or token. Required if image registry is private. </td>
   </tr>
+  <tr>
+    <td>force_create</td>
+    <td>No</td>
+    <td>Create service forcefully, replaces existing service if any. Only valid for `create` service operation. </td>
+  </tr>  
 
 </table>
 

--- a/README.md
+++ b/README.md
@@ -24,17 +24,37 @@ Kubernetes Cluster with Knative, if you dont have an OpenShift cluster see [try.
   </thead>
 
   <tr>
+    <td>command</td>
+    <td>No</td>
+    <td>The `kn` service command, accepted commands are <code>create</code>, <code>update</code>, <code>apply</code> and <code>delete</code>. 
+    Defaults to <code>create</code>.</td>
+  </tr>
+
+  <tr>
     <td>container_image</td>
     <td>No</td>
-    <td>The container image to use for service. Not required if <code>service_operation</code> is set to <code>delete</code>. </td>
+    <td>The container image to use for the service. Not required if <code>service_operation</code> is set to <code>delete</code>. </td>
   </tr>
 
   <tr>
     <td>force_create</td>
     <td>No</td>
-    <td>Pass `--force` to `kn create` to replace the existing service, instead of failing if the service already exists.
-    Defaults to <code>false</code>.
+    <td>"Pass <code>--force</code> to <code>kn create</code>. If the service already exists,
+    the service will be replaced, instead of kn create failing.
+    This input has no effect if <code>command</code> is not <code>create</code>. Defaults to <code>false</code>.
     </td>
+  </tr>
+
+  <tr>
+    <td>kn_extra_args</td>
+    <td>No</td>
+    <td>Any extra arguments to append to the <code>kn 'command'</code> call. </td>
+  </tr>
+
+  <tr>
+    <td>namespace</td>
+     <td>No</td>
+    <td>The Kubernetes Namespace to deploy to. Defaults to current context's namespace. </td>
   </tr>
 
   <tr>
@@ -46,7 +66,7 @@ Kubernetes Cluster with Knative, if you dont have an OpenShift cluster see [try.
   <tr>
     <td>registry_user</td>
     <td>No</td>
-    <td>The registry user to use to create image pull secret. Required if image registry is private. </td>
+    <td>The registry user to use to create the image pull secret. Required if image registry is private. </td>
   </tr>
 
   <tr>
@@ -55,25 +75,6 @@ Kubernetes Cluster with Knative, if you dont have an OpenShift cluster see [try.
     <td>
       The Knative Service name.
     </td>
-  </tr>
-
-  <tr>
-    <td>service_namespace</td>
-     <td>No</td>
-    <td>The Kubernetes Namespace to deploy to. Defaults to current context's namespace. </td>
-  </tr>
-
-  <tr>
-    <td>service_operation</td>
-    <td>No</td>
-    <td>The `kn` service operation <code>create</code>, <code>update</code>, <code>apply</code> <code>delete</code>. 
-    Defaults to <code>create</code>.</td>
-  </tr>
-
-  <tr>
-    <td>service_params</td>
-    <td>No</td>
-    <td>The extra service parameters to pass to the service. </td>
   </tr>
 
 </table>
@@ -92,7 +93,7 @@ Kubernetes Cluster with Knative, if you dont have an OpenShift cluster see [try.
     <td>service_url</td>
     <td>
       Knative Service URL of the service created.
-      Will not be present if <code>service_operation</code> input is set to <code>delete</code>
+      Will be empty if <code>command</code> input is set to <code>delete</code>
     </td>
   </tr>
 
@@ -104,7 +105,7 @@ When username and password or token is provided to pull the image, then the acti
 
 ## Passing extra service arguments
 
-This action provides basic options such as namespace, service name, image and operation to be configured. There might be cases where you might want to pass extra arguments to the `kn service <command>`, in those cases you can use `service_params` as shown:
+This action provides basic options such as namespace, service name, image and command to be configured. There might be cases where you might want to pass extra arguments to the `kn service <command>`, in those cases you can use `kn_extra_args` as shown:
 
 Consider an example that you want to add `--max-scale=5` and `--min-scale=1`, then your action snippet will be:
 
@@ -115,7 +116,7 @@ Consider an example that you want to add `--max-scale=5` and `--min-scale=1`, th
   with: 
     service_name: fruits-app
     container_image: "${{ steps.push-tag-to-quay.outputs.registry-path }}"
-    service_params: >
+    kn_extra_args: >
       --max-scale=5
       --min-scale=1
 ```
@@ -148,15 +149,3 @@ Here OpenShift is used as the Kubernetes platform, you can use the [oc-login act
 ```
 
 For a complete example see [the example workflow](./.github/workflows/example.yml).
-
-## Contributing
-
-This is an open source project open to anyone. This project welcomes contributions and suggestions!
-
-## Feedback & Questions
-
-If you discover an issue please file a bug in [GitHub Issues](https://github.com/redhat-actions/kn-service-deploy/issues) and we will fix it as soon as possible.
-
-## License
-
-MIT, See [LICENSE](./LICENSE) for more information.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Kubernetes Cluster with Knative, if you dont have an OpenShift cluster see [try.
     <td>service_name</td>
     <td>Yes</td>
     <td>
-      The Knative Service Name.
+      The Knative Service name.
     </td>
   </tr>
 
@@ -40,14 +40,14 @@ Kubernetes Cluster with Knative, if you dont have an OpenShift cluster see [try.
   <tr>
     <td>service_operation</td>
     <td>No</td>
-    <td>The `kn` service operation <code>create</code>, <code>update</code>, <code>apply</code> etc. 
-    Defaults to <code>create</code></td>
+    <td>The `kn` service operation <code>create</code>, <code>update</code>, <code>apply</code> <code>delete</code>. 
+    Defaults to <code>create</code>.</td>
   </tr>
 
   <tr>
     <td>container_image</td>
-    <td>Yes</td>
-    <td>The container image to use for service. </td>
+    <td>No</td>
+    <td>The container image to use for service. Not required if <code>service_operation</code> is set to <code>delete</code>. </td>
   </tr>
 
   <tr>
@@ -68,7 +68,9 @@ Kubernetes Cluster with Knative, if you dont have an OpenShift cluster see [try.
   <tr>
     <td>force_create</td>
     <td>No</td>
-    <td>Create service forcefully, replaces existing service if any. Only valid for `create` service operation. </td>
+    <td>Create service forcefully, replaces existing service if any. Only valid for <code>create</code> service operation.
+    Defaults to <code>false</code>.
+     </td>
   </tr>  
 
 </table>
@@ -87,6 +89,7 @@ Kubernetes Cluster with Knative, if you dont have an OpenShift cluster see [try.
     <td>service_url</td>
     <td>
       Knative Service URL of the service created.
+      Will not be present if <code>service_operation</code> input is set to <code>delete</code>
     </td>
   </tr>
 

--- a/action.yml
+++ b/action.yml
@@ -29,8 +29,8 @@ inputs:
     required: false
   force_create:
     description: |
-      "Create service forcefully, replaces existing service if any.
-      Only valid for create service operation"
+      "Pass --force to kn create to replace the existing service,
+      instead of failing if the service already exists.
     required: false
     default: "false"
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -8,29 +8,30 @@ inputs:
   service_name:
     description: "The Knative Service Name"
     required: true
-  service_namespace:
+  namespace:
     description: "The Kubernetes Namespace to deploy to. Defaults to current context's namespace."
     required: false
-  service_operation:
-    description: "The Knative Service Operation"
+  command:
+    description: "The Knative service command, accepted commands are create, update, apply and delete"
     required: false
     default: "create"
   container_image:
     description: "The Knative Service Image"
     required: true
-  service_params:
-    description: "The extra parameter to pass to service"
+  kn_extra_args:
+    description: "Any extra arguments to append to the kn <command>"
     required: false
   registry_user:
-    description: "The registry user to use to create image pull secret"
+    description: "The registry user to use to create the image pull secret"
     required: false
   registry_password:
     description: "The registry user password"
     required: false
   force_create:
     description: |
-      "Pass --force to kn create to replace the existing service,
-      instead of failing if the service already exists.
+      "Pass --force to kn create. If the service already exists,
+      the service will be replaced, instead of kn create failing.
+      This input has no effect if command is not create"
     required: false
     default: "false"
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -27,17 +27,15 @@ inputs:
   registry_password:
     description: "The registry user password"
     required: false
+  force_create:
+    description: |
+      "Create service forcefully, replaces existing service if any.
+      Only valid for create service operation"
+    required: false
+    default: "false"
 outputs:
   service_url:
     description: "The Knative Service URL"
 runs:
   using: "docker"
   image: "Dockerfile"
-  args:
-    - ${{ inputs.service_name }}
-    - ${{ inputs.service_namespace }}
-    - ${{ inputs.service_operation }}
-    - ${{ inputs.container_image }}
-    - ${{ inputs.service_params }}
-    - ${{ inputs.registry_user }}
-    - ${{ inputs.registry_password }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,6 +23,19 @@ fi
 #################################################
 ##
 #################################################
+
+# Delete kn service if service operation is set to 'delete'
+if [[ $INPUT_SERVICE_OPERATION == "delete" ]];
+then
+  appendParams "delete"
+  appendParams "$INPUT_SERVICE_NAME"
+  echo "⏳ Running: ${kn_command[*]} "
+  echo "⏳ Deleting $INPUT_SERVICE_NAME service"
+  ${kn_command[*]}
+  echo "✅ $INPUT_SERVICE_NAME service successfully deleted"
+  exit 0
+fi
+
 docker_server="${INPUT_CONTAINER_IMAGE%/*/*}"
 secret_name="$docker_server.pull-secret"
 is_private_registry=false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -75,7 +75,7 @@ esac
 
 # Add an extra parameters to the service
 OLDIFS=$IFS
-if [[ -n $INPUT_KN_EXTRA_ARGS
+if [[ -n $INPUT_KN_EXTRA_ARGS ]]
 then
   IFS=$'\n'
   kn_command+=("${INPUT_KN_EXTRA_ARGS}")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,9 +52,13 @@ case $INPUT_SERVICE_OPERATION in
     && appendParams "--pull-secret=$secret_name"
    ;;
   *)
-   printf "%s is not a valid kn service command" "$INPUT_SERVICE_OPERATION"
+   printf "❌ %s is not a valid kn service command" "$INPUT_SERVICE_OPERATION"
   ;;
 esac
+
+# Add force flag in create command
+[[ "$INPUT_SERVICE_OPERATION" == "create" ]] && [[ "$INPUT_FORCE_CREATE" != "false" ]] \
+    && appendParams "--force"
 
 # Add an extra parameters to the service
 OLDIFS=$IFS
@@ -65,10 +69,11 @@ then
   IFS=$OLDIFS
 fi
 
-echo "Running: ${kn_command[*]} "
+echo "⏳ Running: ${kn_command[*]} "
 ${kn_command[*]}
 
 # After successful service creation extract the service url 
 # and set that as output to the action
+echo "✅ $INPUT_SERVICE_NAME service created successfully."
 service_url=$(kn service describe $namespace_arg "$INPUT_SERVICE_NAME" -o url)
 echo "::set-output name=service_url::$service_url"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,9 +13,9 @@ kn_command=("kn" "service")
 
 namespace_arg=""
 
-if [[ -n $INPUT_SERVICE_NAMESPACE ]]; then
-    echo "Setting service namespace to '$INPUT_SERVICE_NAMESPACE'"
-    namespace_arg="--namespace=$INPUT_SERVICE_NAMESPACE"
+if [[ -n $INPUT_NAMESPACE ]]; then
+    echo "Setting service namespace to '$INPUT_NAMESPACE'"
+    namespace_arg="--namespace=$INPUT_NAMESPACE"
 else
     echo "No namespace provided"
 fi
@@ -24,8 +24,8 @@ fi
 ##
 #################################################
 
-# Delete kn service if service operation is set to 'delete'
-if [[ $INPUT_SERVICE_OPERATION == "delete" ]];
+# Delete kn service if service command is set to 'delete'
+if [[ $INPUT_COMMAND == "delete" ]];
 then
   appendParams "delete"
   appendParams "$INPUT_SERVICE_NAME"
@@ -54,31 +54,31 @@ then
   is_private_registry=true
 fi
 
-appendParams "$INPUT_SERVICE_OPERATION"
+appendParams "$INPUT_COMMAND"
 appendParams "$INPUT_SERVICE_NAME"
 appendParams $namespace_arg
 
-case $INPUT_SERVICE_OPERATION in
+case $INPUT_COMMAND in
   create | update | apply )
     appendParams "--image=$INPUT_CONTAINER_IMAGE"
     [[ "$is_private_registry" != "false" ]] \
     && appendParams "--pull-secret=$secret_name"
    ;;
   *)
-   printf "❌ %s is not a valid kn service command" "$INPUT_SERVICE_OPERATION"
+   printf "❌ %s is not a valid kn service command" "$INPUT_COMMAND"
   ;;
 esac
 
 # Add force flag in create command
-[[ "$INPUT_SERVICE_OPERATION" == "create" ]] && [[ "$INPUT_FORCE_CREATE" != "false" ]] \
+[[ "$INPUT_COMMAND" == "create" ]] && [[ "$INPUT_FORCE_CREATE" != "false" ]] \
     && appendParams "--force"
 
 # Add an extra parameters to the service
 OLDIFS=$IFS
-if [[ -n $INPUT_SERVICE_PARAMS ]];
+if [[ -n $INPUT_KN_EXTRA_ARGS
 then
   IFS=$'\n'
-  kn_command+=("${INPUT_SERVICE_PARAMS}")
+  kn_command+=("${INPUT_KN_EXTRA_ARGS}")
   IFS=$OLDIFS
 fi
 


### PR DESCRIPTION
- `--force` command is valid only for `create` service operation.
- Added another input `force_create` if set to true it will delete the
existing knative service and create another one.
- Added `delete` service operation that will delete the kn service.
- Modify README to arrange inputs alphabetically